### PR TITLE
Fix wrong keys being checked for strafe rolling

### DIFF
--- a/src/main/java/dev/enjarai/rollingdowninthedeep/StrafeRollModifiers.java
+++ b/src/main/java/dev/enjarai/rollingdowninthedeep/StrafeRollModifiers.java
@@ -33,10 +33,10 @@ public class StrafeRollModifiers {
         }
         double velocityStrength = 50 * speedMult;
 
-        if (options.keyLeft.isDown() && !options.keyLeft.isDown()) {
+        if (options.keyLeft.isDown() && !options.keyRight.isDown()) {
             rollDelta = -SwimConfig.INSTANCE.strafeRollStrength;
             yawDelta = -SwimConfig.INSTANCE.strafeYawStrength;
-        } else if (options.keyLeft.isDown() && !options.keyLeft.isDown()) {
+        } else if (options.keyRight.isDown() && !options.keyLeft.isDown()) {
             rollDelta = SwimConfig.INSTANCE.strafeRollStrength;
             yawDelta = SwimConfig.INSTANCE.strafeYawStrength;
         }


### PR DESCRIPTION
ummm i dont really know what im doing or how to test this (i dont make mods or anything) but this was broken on neoforge 1.21.1 and umm. it looked like a simple enough fix so i hope this is ok!